### PR TITLE
Fsa22 v2 78 gilded rose conjured item

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "printWidth": 80,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "endOfLine": "lf"
+}

--- a/src/inventory/gilded_rose.js
+++ b/src/inventory/gilded_rose.js
@@ -21,6 +21,7 @@ const items = [
 
 updateQuality(items);
 */
+////-----STILL to DO: get conjured item working/tests passing and in updateQuality pull out functionality for update default item and update Sulfuras
 
 const qualityIncWithAge = ['Aged Brie'];
 const qualityIncFastAsExpiring = ['Backstage passes to a TAFKAL80ETC concert'];
@@ -33,10 +34,12 @@ const qualityUpdater = (item, change_Amount) => {
   if (item.sell_in > 0 && item.quality > 0 && item.quality <= 50) {
     item.quality = item.quality + change_Amount;
     return;
+  } 
+  if (item.sell_in < 0) {
+    item.quality = item.quality - 2 * (change_Amount);
+    return;
   }
-  item.quality = item.quality + 2 * change_Amount;
 };
-
 const itemExpired = (item) => {
   if (item.sell_in < 0) {
     return true;
@@ -47,15 +50,16 @@ const sell_inDefault = (item) => {
   item.sell_in = item.sell_in - 1;
 };
 
+
 //for Aged Brie
 const agedBrieUpdater = (item) => {
-  sell_inDefault(item);
-  item.quality = item.quality + 1;
-};
+  if (item.quality < 50){
+  qualityUpdater(item, 1);
+}
+}
 
 //for Backstage Pass
 const backstagePassUpdater = (item) => {
-  // if (item.quality < 50) {
   if (item.sell_in < 6) {
     qualityUpdater(item, 3);
   } else if (item.sell_in < 11) {
@@ -65,19 +69,22 @@ const backstagePassUpdater = (item) => {
   }
 };
 
-// }
+//for conjured item
+const conjuredItemUpdater = (item) => {
+  qualityUpdater(item, -2);
+}
 
-//for any item
+//for default item
 const defaultItemUpdater = (item) => {
   if (!qualityIncWithAge && !qualityIncFastAsExpiring && !constantQuality) {
-    item.quality = item.quality - 1;
-  }
-};
+    qualityUpdater(item, 1);
+  };
+}
 
 export function updateQuality(items) {
   for (var i = 0; i < items.length; i++) {
     const item = items[i];
-
+ 
     //update quality for Aged Brie
     if (item.name === 'Aged Brie') {
       //update aged brie here
@@ -86,16 +93,24 @@ export function updateQuality(items) {
       continue;
     }
 
+       
+    //update quality for Conjured Item
+    if (item.name === 'Conjured Item'){
+      conjuredItemUpdater(item);
+      continue;
+    }
+
     //update quality for Backstage Pass
     if (!qualityIncFastAsExpiring.includes(item.name)) {
       if (!constantQuality.includes(item.name)) {
         qualityUpdater(item, -1);
+        
       }
     } else if (item.quality < 50) {
       backstagePassUpdater(item);
-    }
+    } 
 
-    //update quality for Default Item
+    //sell_in for all items (decrease by one each day)
     if (!constantQuality.includes(item.name)) {
       sell_inDefault(item);
     }
@@ -110,13 +125,12 @@ export function updateQuality(items) {
         //condition for when it IS Sufuras
       } else if (constantQuality.includes(item.name)) {
         return; //return nothing: no quality change for him
-      } else {
-        qualityUpdater(item, -1);
-      }
+      } 
+      //default items
+      qualityUpdater(item, 1);
+     
     }
 
-    //closes for loop
   }
 
-  //updateQuality() outermost function bracket
 }

--- a/src/inventory/gilded_rose.spec.js
+++ b/src/inventory/gilded_rose.spec.js
@@ -10,9 +10,9 @@ describe('updateQuality', () => {
     });
     // ----Quality deprecates by double for sell_in < 0----//
     it('deprecates quality by double when sell_in<0', () => {
-      const standardItem = new Item('Haunted Shoe', 0, 5);
+      const standardItem = new Item('Haunted Shoe', 0, 7);
       updateQuality([standardItem]);
-      expect(standardItem.quality).toBe(3);
+      expect(standardItem.quality).toBe(5);
     });
   });
 
@@ -20,15 +20,14 @@ describe('updateQuality', () => {
   // increase sell_in to 3 and quality to 1 --passes
   describe('when updating Aged Brie', () => {
     it('increase quality of Aged Brie with age', () => {
-      const standardItem = new Item('Aged Brie', 3, 0);
+      const standardItem = new Item('Aged Brie', 3, 4);
       updateQuality([standardItem]);
-      expect(standardItem.quality).toBe(1);
+      expect(standardItem.quality).toBe(5);
     });
 
     // ----Quality of item is never >50----//
-    // increase quality to 49 --passes
-    it('increase quality of Aged Brie with age', () => {
-      const standardItem = new Item('Aged Brie', 15, 49);
+    it('max quality of Aged Brie is 50', () => {
+      const standardItem = new Item('Aged Brie', 15, 50);
       updateQuality([standardItem]);
       expect(standardItem.quality).toBe(50);
     });
@@ -124,5 +123,14 @@ describe('updateQuality', () => {
     updateQuality([standardItem]);
 
     expect(standardItem.quality).toBe(6);
+  });
+
+  // Conjured Item Test
+  describe('when updating conjured item', () => {
+    it('deprecates the quality by double', () => {
+      const standardItem = new Item('Conjured Item', 10, 30);
+      updateQuality([standardItem]);
+      expect(standardItem.quality).toBe(28);
+    });
   });
 });


### PR DESCRIPTION
## Description
Add Support for Conjured Items

## Spec

See Issue: [FSA22V2-78](https://sparkbox.atlassian.net/browse/FSA22V2-78?atlOrigin=eyJpIjoiMDdiZTBlZDU1YjEyNDgxNDg0NGU1ODE4MzFlMzMxZjIiLCJwIjoiaiJ9)

## Validation

- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR has new code, so new tests were added or updated, and they pass.

- The degradation of conjured items should relate to that of normal items instead of hardcoding that conjured items decrease by two until the sell-in date, and then they decrease by four.

### To Validate

1. Make sure all PR Checks have passed.
2. Pull down all related branches.
3. The inventory system is updated to degrade the quality of conjured items according to the business logic.
4. Conjured items  behavior is covered by tests.
