### PR TITLE
Fsa22 v2 79 reset inventory

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -1,10 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/css/homepage.css" type='text/css' media='screen'>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="/css/homepage.css"
+      type="text/css"
+      media="screen"
+    />
     <script type="module" src="/js/homepage_items.js"></script>
     <title>Gilded Rose</title>
   </head>
@@ -19,9 +24,10 @@
         </tr>
       </thead>
       <tbody></tbody>
-  </table>
-  <form class="form">
-    <button id="update-items-button">Update Items</button>
-  </form>
+    </table>
+    <form class="form">
+      <button id="update-items-button">Update Items</button>
+      <button id="reset-inv-button">Reset</button>
+    </form>
   </body>
 </html>

--- a/src/inventory/gilded_rose.js
+++ b/src/inventory/gilded_rose.js
@@ -21,7 +21,6 @@ const items = [
 
 updateQuality(items);
 */
-////-----STILL to DO: get conjured item working/tests passing and in updateQuality pull out functionality for update default item and update Sulfuras
 
 const qualityIncWithAge = ['Aged Brie'];
 const qualityIncFastAsExpiring = ['Backstage passes to a TAFKAL80ETC concert'];
@@ -62,11 +61,14 @@ const agedBrieUpdater = (item) => {
 const backstagePassUpdater = (item) => {
   if (item.sell_in < 6) {
     qualityUpdater(item, 3);
-  } else if (item.sell_in < 11) {
+    return
+  } 
+  if (item.sell_in < 11) {
     qualityUpdater(item, 2);
-  } else {
+    return
+  } 
     qualityUpdater(item, 1);
-  }
+ 
 };
 
 //for conjured item
@@ -84,7 +86,11 @@ const defaultItemUpdater = (item) => {
 export function updateQuality(items) {
   for (var i = 0; i < items.length; i++) {
     const item = items[i];
- 
+    
+    if (item.name === 'Sulfuras'){
+      continue;
+    }
+
     //update quality for Aged Brie
     if (item.name === 'Aged Brie') {
       //update aged brie here
@@ -101,14 +107,19 @@ export function updateQuality(items) {
     }
 
     //update quality for Backstage Pass
+    if (item.name === 'Backstage passes to a TAFKAL80ETC concert'){
+      if (item.quality < 50) {
+      backstagePassUpdater(item);
+      }
+      qualityUpdater(item, -1);
+    }
+
     if (!qualityIncFastAsExpiring.includes(item.name)) {
       if (!constantQuality.includes(item.name)) {
         qualityUpdater(item, -1);
         
       }
-    } else if (item.quality < 50) {
-      backstagePassUpdater(item);
-    } 
+     } 
 
     //sell_in for all items (decrease by one each day)
     if (!constantQuality.includes(item.name)) {
@@ -117,15 +128,13 @@ export function updateQuality(items) {
 
     //where items expire
     if (itemExpired(item)) {
-      if (!qualityIncWithAge.includes(item.name)) {
+      
         if (qualityIncFastAsExpiring.includes(item.name)) {
           //backstage passes go to zero after concert
           item.quality = item.quality - item.quality;
         }
-        //condition for when it IS Sufuras
-      } else if (constantQuality.includes(item.name)) {
-        return; //return nothing: no quality change for him
-      } 
+        
+      
       //default items
       qualityUpdater(item, 1);
      

--- a/src/inventory/gilded_rose.js
+++ b/src/inventory/gilded_rose.js
@@ -21,6 +21,7 @@ const items = [
 
 updateQuality(items);
 */
+////-----STILL to DO: get conjured item working/tests passing and in updateQuality pull out functionality for update default item and update Sulfuras
 
 const qualityIncWithAge = ['Aged Brie'];
 const qualityIncFastAsExpiring = ['Backstage passes to a TAFKAL80ETC concert'];
@@ -61,14 +62,11 @@ const agedBrieUpdater = (item) => {
 const backstagePassUpdater = (item) => {
   if (item.sell_in < 6) {
     qualityUpdater(item, 3);
-    return
-  } 
-  if (item.sell_in < 11) {
+  } else if (item.sell_in < 11) {
     qualityUpdater(item, 2);
-    return
-  } 
+  } else {
     qualityUpdater(item, 1);
- 
+  }
 };
 
 //for conjured item
@@ -86,11 +84,7 @@ const defaultItemUpdater = (item) => {
 export function updateQuality(items) {
   for (var i = 0; i < items.length; i++) {
     const item = items[i];
-    
-    if (item.name === 'Sulfuras'){
-      continue;
-    }
-
+ 
     //update quality for Aged Brie
     if (item.name === 'Aged Brie') {
       //update aged brie here
@@ -107,19 +101,14 @@ export function updateQuality(items) {
     }
 
     //update quality for Backstage Pass
-    if (item.name === 'Backstage passes to a TAFKAL80ETC concert'){
-      if (item.quality < 50) {
-      backstagePassUpdater(item);
-      }
-      qualityUpdater(item, -1);
-    }
-
     if (!qualityIncFastAsExpiring.includes(item.name)) {
       if (!constantQuality.includes(item.name)) {
         qualityUpdater(item, -1);
         
       }
-     } 
+    } else if (item.quality < 50) {
+      backstagePassUpdater(item);
+    } 
 
     //sell_in for all items (decrease by one each day)
     if (!constantQuality.includes(item.name)) {
@@ -128,13 +117,15 @@ export function updateQuality(items) {
 
     //where items expire
     if (itemExpired(item)) {
-      
+      if (!qualityIncWithAge.includes(item.name)) {
         if (qualityIncFastAsExpiring.includes(item.name)) {
           //backstage passes go to zero after concert
           item.quality = item.quality - item.quality;
         }
-        
-      
+        //condition for when it IS Sufuras
+      } else if (constantQuality.includes(item.name)) {
+        return; //return nothing: no quality change for him
+      } 
       //default items
       qualityUpdater(item, 1);
      

--- a/src/js/homepage_items.js
+++ b/src/js/homepage_items.js
@@ -35,10 +35,21 @@ const bindEventListenToUpdateButton = (items) => {
   });
 };
 
+const bindEventListenToResetButton = () => {
+  const updateReset = document.getElementById('reset-inv-button');
+  updateReset.addEventListener('click', (e) => {
+    e.preventDefault();
+    // resets to object of default items
+    renderItemsOnHomepage(getNewItems());
+  });
+};
+
 const showItemsOnHomePage = () => {
   const items = getNewItems();
   renderItemsOnHomepage(items);
   bindEventListenToUpdateButton(items);
+  // no items passed in, it's resetting to default
+  bindEventListenToResetButton();
 };
 
 showItemsOnHomePage();


### PR DESCRIPTION
## Description
Add Support for Resetting Inventory

## Spec

See Issue: [FSA22V2-79](https://sparkbox.atlassian.net/browse/FSA22V2-79?atlOrigin=eyJpIjoiZjYwYTBhOGI3ZmIxNGI5NWI3ZWFmNjhmZTZjMGY1MjYiLCJwIjoiaiJ9)

## Validation
<!-- delete anything irrelevant to this PR -->

- [x] This PR has code changes, and our linters still pass.
- [x] This PR has new code, so new tests were added or updated, and they pass.

  -create const bindEventListenToResetButton
    -create updateReset const
    -add getNewItems input to renderItemsOnHomepage function to reset
    items to default group
    -in const showItemsOnHomePage add bindEventListenToResetButton function
    with no input so it uses default item values

### To Validate

1. Make sure all PR Checks have passed.
2. Pull down all related branches.
3. Users can click a button on the homepage to reset all of the inventory items.

